### PR TITLE
fix: updated .gitignore to ignore common virtual environment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 site
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pythonenv*


### PR DESCRIPTION
List of directories taken from https://www.toptal.com/developers/gitignore/api/python